### PR TITLE
Clean stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,22 @@
 This guide will run you through setting up MongoDB on a cloud provider and connecting to the database instance remotely via C#. _**Note: You must whitelist your IP address for clusters to work correctly**_.
 
 1. [Build / Run](#Build-/-Run)
-2. [Visual Studio Setup](#Visual-Studio-Setup) ("Visual Studio" referred as "VS")
-3. [Atlas Setup](#Atlas-Setup)
+1. [Test](#Test)
+1. [Visual Studio Setup](#Visual-Studio-Setup) ("Visual Studio" referred as "VS")
+1. [Import Data](#Import-Data)
+1. [Atlas Setup](#Atlas-Setup)
     * [Atlas Firewall](#Atlas-Firewall)
     * [Establish Connection](#Establish-Connection)
-4. [GCP Setup](#GCP-Setup)
+1. [GCP Setup](#GCP-Setup)
     * [GCP Firewall](#GCP-Firewall)
-5. [TODOs](#TODOs)
-6. [Stretch Goals](#Stretch-Goals)
-7. [Resources](#Resources)
+1. [TODOs](#TODOs)
+1. [Stretch Goals](#Stretch-Goals)
+1. [Resources](#Resources)
     * [Tooling Versions](#Tooling-Versions)
+1. [Troubleshooting](#Troubleshooting)
 
 <br>
 <hr/>
-
 ## Build / Run
 * Clone the project: `git clone git@github.com:PieMyth/CloudCluster.git`
 
@@ -25,17 +27,19 @@ This guide will run you through setting up MongoDB on a cloud provider and conne
 * Run the project by going to the main program directory *\*/CloudCluster/mongoCluster/* and run the command:  
 
   ​    `dotnet run`
-
-* Test the project by going into the test directory *\*/CloudCluster/mongoCluster.Test/* and run the command :  
+<br>
+<hr/>
+## Test
+* Run the unit tests through Visual Studio by selecting `Test >> Run All Tests` 
+* Alternately, test the project by going into the test directory *\*/CloudCluster/mongoCluster.Test/* and run the command :  
 
   ​    `dotnet test`
 <br>
 <hr/>
-
 ## Visual Studio Setup
 1. Select the solution in order to build the driver correctly. This can be found in the `CloudCluster` directory: `CloudCluster.sln`
-2. Copy the connection string and put it in the connection_string variable in the program file
-3. Via the Nuget package manager in VS, install relevant packages:
+1. Copy the connection string and put it in the connection_string variable in the program file
+1. Via the Nuget package manager in VS, install relevant packages:
     - Mongo C# Driver Packages
       * ***MongoDB.Driver.Core***
       * ***MongoDB.Bson***
@@ -50,38 +54,22 @@ This guide will run you through setting up MongoDB on a cloud provider and conne
     - Config file package
       - ***System.Configuration.ConfigurationManager***
     - Validation Packages
-      - ***MSTest.TestFramework***
       - ***xunit***
-      - ***xunit.runner.visualstudio***
-
-4. Change the connection string in App.config to point to your cluster's connection string
-
-5. If importing .csv or .json files from a folder:
+    
+1. Change the connection string in App.config to point to your cluster's connection string
+1. If importing data with C#, set the `importData` boolean to `true` in Program.cs
+1. If deleting all collections, set the `deleteAll` boolean to `true` in Program.cs
+<br>
+<hr/>
+## Import Data
+If importing .csv or .json files from a folder:
     - Unzip the 'dataset.zip' file from the project root directory
     - Edit the listingsFolder and reviewsFolder in App.config to point to the import folder locations
     - Be sure to untar or unzip files so that they are in either .csv or .json!
     - Set the 'importData' boolean in Program.cs to true
     - Note: Do not have the imported file open in any other programs while running, or VS can't get a lock on the file
-
-6. If deleting all collections:
-    - Set the 'deleteAll' boolean in Program.cs to true
-
-7. If having trouble running tests, check that the App.config file is properly linked to the test directory
-    - In the Solution Explorere panel, right-click on 'mongoCluster.Tests'
-    - Add > Existing Item...
-    - File type: All Files (*.*)
-    - Navigate to the mongoCluster folder and select 'App.config'
-    - Press the down arrow next to 'Add', select 'Add as Link'
-
-8. If having trouble seeing input from the console:
-    - Ensure that Nlog and Nlog.Config packages have been installed 
-    - Check NLog.config for specifying logger printing output and output rules
-    - Download NLog.xsd, save as All Files (*.*) with extension .xsd, place in mongoCluster directory
-    - Right click on the NLog.config file from visual studio, select properties, Copy to Output > Copy if Newer
-
 <br>
 <hr/>
-
 ## Atlas Setup
 1. Navigate to the MongoDB Atlas website
 1. Build a new cluster
@@ -117,7 +105,6 @@ This guide will run you through setting up MongoDB on a cloud provider and conne
 1. You do not need to turn on or turn off clusters as Atlas manages this for you
 <br>
 <hr/>
-
 ## GCP Setup
 From the first link, 'MongoDB on Compute Engine'...
 1. Click *Launch on Compute Engine*
@@ -156,7 +143,6 @@ From the first link, 'MongoDB on Compute Engine'...
 1. Save
 <br>
 <hr/>
-
 ## TODOs
 - Set up Atlas clusters on AWS, GCP, and Azure
 - Use cursors to parse through large query results
@@ -173,7 +159,6 @@ From the first link, 'MongoDB on Compute Engine'...
     - Workaround: use C#'s Datetime.Now() for query runtime & take an average of performance
 <br>
 <hr/>
-
 ## Stretch Goals
 - Execute import & queries asynchronously
 - Log errors onto a local file (set this up in the Nlog.Config file)
@@ -189,7 +174,6 @@ From the first link, 'MongoDB on Compute Engine'...
     - If we figure out the service account, this is very do-able! It would just be a change of connection string.
 <br>
 <hr/>
-
 ## Resources
 <i>
 
@@ -210,3 +194,17 @@ From the first link, 'MongoDB on Compute Engine'...
 ### Tooling Versions
 * Visual Studio 2019
 <hr/>
+## Troubleshooting
+
+1. If having trouble running tests, check that the App.config file is properly linked to the test directory
+    - In the Solution Explorere panel, right-click on 'mongoCluster.Tests'
+    - Add > Existing Item...
+    - File type: All Files (*.*)
+    - Navigate to the mongoCluster folder and select 'App.config'
+    - Press the down arrow next to 'Add', select 'Add as Link'
+
+2. If having trouble seeing input from the console:
+    - Ensure that Nlog and Nlog.Config packages have been installed 
+    - Check NLog.config for specifying logger printing output and output rules
+    - Download NLog.xsd, save as All Files (*.*) with extension .xsd, place in mongoCluster directory
+    - Right click on the NLog.config file from visual studio, select properties, Copy to Output > Copy if Newer

--- a/mongoCluster/Driver.cs
+++ b/mongoCluster/Driver.cs
@@ -132,7 +132,7 @@ namespace mongoCluster
                 // Does nothing if file already exists
                 filePath.Directory.Create();
             }
-            catch (System.IO.IOException err)
+            catch (IOException err)
             {
                 logger.Error($"Error: Failed to create query output directory: {err}");
                 return false;
@@ -141,18 +141,18 @@ namespace mongoCluster
         }
 
         /// <summary>Creates the directories and file for storing query output to an external file.</summary>
+        /// <param name="file">A reference to the file path to create</param>
+        /// <param name="functionName">The function name to store</param>
         /// <returns>True if created file, False, otherwise</returns>
-        private bool _prepareQueryOutput(string functionName, ref System.IO.FileInfo file)
+        private bool _prepareQueryOutput(string functionName, ref FileInfo file)
         {
             // Create the absolute path to the output .txt file for this query
             String fileName = functionName + ".txt";
             String filePath = _getOutputPath(Path.Combine(_outputFolder, fileName));
-            file = new System.IO.FileInfo(_getOutputPath(filePath));
+            file = new FileInfo(_getOutputPath(filePath));
 
             // Create the directories for the output path if they do not already exist
-            if (!_createFile(ref file))
-                return false;
-            return true;
+            return this._createFile(ref file);
         }
 
         /// <summary>A Query that counts the total number of documents in a collection</summary>
@@ -200,13 +200,13 @@ namespace mongoCluster
         public bool queryCount(String collectionName)
         {
             // Prepare the external file to store this query's output
-            System.IO.FileInfo file = null;
+            FileInfo file = null;
             if (!_prepareQueryOutput(MethodBase.GetCurrentMethod().Name, ref file))
                 return false;
 
             // Open external file for storing query output, clears out previous text
-            using (System.IO.StreamWriter fout =
-                new System.IO.StreamWriter(file.FullName))
+            using (StreamWriter fout =
+                new StreamWriter(file.FullName))
             {
                 String output;
                 DateTime start;
@@ -243,7 +243,28 @@ namespace mongoCluster
         /// <param name="collectionName">String representing the collection</param>
         public bool querySortedSubset(String collectionName)
         {
-            return _querySortedSubset(collectionName);
+            string queryName = "Query 2 - Sorted Subset";
+            FileInfo file = null;
+            DateTime start;
+
+            // Prepare the external file to store this query's output
+            if (!_prepareQueryOutput(MethodBase.GetCurrentMethod().Name, ref file))
+                return false;
+
+            // Open external file (clearing previous content if necessary)
+            // Record start/end time metrics, query results to file
+            using (StreamWriter fout = new StreamWriter(file.FullName))
+            {
+                start = this._startQueryMetrics(queryName, fout);
+
+                // Run the query
+                if (!this._querySortedSubset(collectionName, fout)) {
+                    this._stopQueryMetrics(fout, start);
+                    return false;
+                }
+                this._stopQueryMetrics(fout, start);
+            }
+            return true;
         }
 
         /// <summary>
@@ -253,7 +274,28 @@ namespace mongoCluster
         /// <param name="collectionName">String representing the collection</param>
         public bool querySubsetSearch(String collectionName)
         { 
-            return _querySubsetSearch(collectionName);
+            string queryName = "Query 3 - Subset Search";
+            FileInfo file = null;
+            DateTime start;
+
+            // Prepare the external file to store this query's output
+            if (!_prepareQueryOutput(MethodBase.GetCurrentMethod().Name, ref file))
+                return false;
+
+            // Open external file (clearing previous content if necessary)
+            // Record start/end time metrics, query results to file
+            using (StreamWriter fout = new StreamWriter(file.FullName))
+            {
+                start = this._startQueryMetrics(queryName, fout);
+
+                // Run the query
+                if (!this._querySubsetSearch(collectionName, fout)) {
+                    this._stopQueryMetrics(fout, start);
+                    return false;
+                }
+                this._stopQueryMetrics(fout, start);
+            }
+            return true;
         }
 
         /// Query 4: Average
@@ -262,28 +304,91 @@ namespace mongoCluster
         /// <param name="collectionName">String representing the collection</param>
         public bool queryAverage(String collectionName)
         { 
-            return _queryAverage(collectionName);
+            string queryName = "Query 4 - Average";
+            FileInfo file = null;
+            DateTime start;
+
+            // Prepare the external file to store this query's output
+            if (!_prepareQueryOutput(MethodBase.GetCurrentMethod().Name, ref file))
+                return false;
+
+            // Open external file (clearing previous content if necessary)
+            // Record start/end time metrics, query results to file
+            using (StreamWriter fout = new StreamWriter(file.FullName))
+            {
+                start = this._startQueryMetrics(queryName, fout);
+
+                // Run the query
+                if (!this._queryAverage(collectionName, fout)) {
+                    this._stopQueryMetrics(fout, start);
+                    return false;
+                }
+                this._stopQueryMetrics(fout, start);
+            }
+            return true;
         }
 
         /// <summary>
-        /// Query 5: Join
+        /// Query 5: Update
+        /// Update all listings that have more than 2 bedrooms and more than 2 bathrooms from Portland to require guest phone verification.
+        /// </summary>
+        /// <param name="collectionName">String representing the collection</param>
+        public bool queryUpdate(String collectionName)
+        {
+            string queryName = "Query 5 - Update";
+            FileInfo file = null;
+            DateTime start;
+
+            // Prepare the external file to store this query's output
+            if (!_prepareQueryOutput(MethodBase.GetCurrentMethod().Name, ref file))
+                return false;
+
+            // Open external file (clearing previous content if necessary)
+            // Record start/end time metrics, query results to file
+            using (StreamWriter fout = new StreamWriter(file.FullName))
+            {
+                start = this._startQueryMetrics(queryName, fout);
+
+                // Run the query
+                if (!this._queryUpdate(collectionName, fout)) {
+                    this._stopQueryMetrics(fout, start);
+                    return false;
+                }
+                this._stopQueryMetrics(fout, start);
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Query 6: Join
         /// Return the most recent review for all listings from Portland with greater than 3 bedrooms that is also a house.
         /// </summary>
         /// <param name="firstCollection">String representing one collection</param>
         /// <param name="secondCollection">String representing a second collection</param>
         public bool queryJoin(String firstCollection, String secondCollection)
         { 
-            return _queryJoin(firstCollection, secondCollection);
-        }
+            string queryName = "Query 6 - Join";
+            FileInfo file = null;
+            DateTime start;
 
-        /// <summary>
-        /// Query 6: Update
-        /// Update all listings that have more than 2 bedrooms and more than 2 bathrooms from Portland to require guest phone verification.
-        /// </summary>
-        /// <param name="collectionName">String representing the collection</param>
-        public bool queryUpdate(String collectionName)
-        {
-            return _queryUpdate(collectionName);
+            // Prepare the external file to store this query's output
+            if (!_prepareQueryOutput(MethodBase.GetCurrentMethod().Name, ref file))
+                return false;
+
+            // Open external file (clearing previous content if necessary)
+            // Record start/end time metrics, query results to file
+            using (StreamWriter fout = new StreamWriter(file.FullName))
+            {
+                start = this._startQueryMetrics(queryName, fout);
+
+                // Run the query
+                if (!this._queryJoin(firstCollection, secondCollection, fout)) {
+                    this._stopQueryMetrics(fout, start);
+                    return false;
+                }
+                this._stopQueryMetrics(fout, start);
+            }
+            return true;
         }
 
         /// <summary>Establishes connection to database</summary>
@@ -329,10 +434,17 @@ namespace mongoCluster
             // modified from https://stackoverflow.com/questions/25017219/how-to-check-if-collection-exists-in-mongodb-using-c-sharp-driver
             BsonDocument filter = new BsonDocument("name", collectionName);
             var collections = new ListCollectionNamesOptions { Filter = filter };
+            var result = false;
 
-            var result = _db.ListCollectionNames(collections).Any();
-            Console.WriteLine($"collection name results = {result}");
+            try
+            {
+                result = _db.ListCollectionNames(collections).Any();
 
+            }
+            catch (MongoAuthenticationException)
+            {
+                throw new UnauthorizedAccessException();
+            }
             return _db.ListCollectionNames(collections).Any();
         }
 
@@ -503,7 +615,8 @@ namespace mongoCluster
         /// Find the listings with the top 5 highest number of reviews for the entire dataset.
         /// </summary>
         /// <param name="collectionName">String representing the collection</param>
-        private bool _querySortedSubset(String collectionName)
+        /// <param name="fout">StreamWriter stream for for writing out query results</param>
+        private bool _querySortedSubset(String collectionName, StreamWriter fout)
         {
             /*  Implementation Strategy:
             *      1. Perform a sort ($sort) on the number_of_reviews decreasing (-1).
@@ -511,32 +624,8 @@ namespace mongoCluster
             *      3. Limit to the top 5 results ($limit).
             */
             // TODO: stub
-
-            // Prepare the external file to store this query's output
-            System.IO.FileInfo file = null;
-            if (!_prepareQueryOutput(MethodBase.GetCurrentMethod().Name, ref file))
-                return false;
-
-            // Open external file for storing query output, clears out previous text
-            using (System.IO.StreamWriter fout =
-                new System.IO.StreamWriter(file.FullName))
-            {
-                String output;
-                DateTime start;
-
-                Console.WriteLine('\n' + new string('-', 100) + '\n');
-                output = "Query 2 - Sorted Subset";
-                fout.WriteLine(output);
-
-                start = DateTime.UtcNow;
-                // Run query on this line
-                output += $"\nQuery run time: {DateTime.UtcNow - start}";
-                logger.Info(output);
-                fout.WriteLine(output);
-            }
             return false;
         }
-
 
         /// <summary>
         /// Query 3: Subset-search
@@ -544,7 +633,8 @@ namespace mongoCluster
         /// what percentage of these have a strict cancellation policy?
         /// </summary>
         /// <param name="collectionName">String representing the collection</param>
-        private bool _querySubsetSearch(String collectionName)
+        /// <param name="fout">StreamWriter stream for for writing out query results</param>
+        private bool _querySubsetSearch(String collectionName, StreamWriter fout)
         {
             /*  Implementation Strategy:
             *      1. Perform a filter on the data to only grab documents where property_type is equal to “House”.
@@ -555,29 +645,6 @@ namespace mongoCluster
             *         This can then be formatted to get this count divided by the total number of documents to gather a percentage
             */
             // TODO: stub
-
-            // Prepare the external file to store this query's output
-            System.IO.FileInfo file = null;
-            if (!_prepareQueryOutput(MethodBase.GetCurrentMethod().Name, ref file))
-                return false;
-
-            // Open external file for storing query output, clears out previous text
-            using (System.IO.StreamWriter fout =
-                new System.IO.StreamWriter(file.FullName))
-            {
-                String output;
-                DateTime start;
-
-                Console.WriteLine('\n' + new string('-', 100) + '\n');
-                output = "Query 3 - Subset-search";
-                fout.WriteLine(output);
-
-                start = DateTime.UtcNow;
-                // Run query on this line
-                output += $"\nQuery run time: {DateTime.UtcNow - start}";
-                logger.Info(output);
-                fout.WriteLine(output);
-            }
             return false;
         }
 
@@ -586,46 +653,41 @@ namespace mongoCluster
         /// Find the average host response rate for listings with a price per night over $1000.
         /// </summary>
         /// <param name="collectionName">String representing the collection</param>
-        private bool _queryAverage(String collectionName)
+        /// <param name="fout">StreamWriter stream for for writing out query results</param>
+        private bool _queryAverage(String collectionName, StreamWriter fout)
         {
             /*  Implementation Strategy:
             *      1. Perform a filter to find listings with price greater than $1000 ($gt)
             *      2. Perform an average aggregation for the average host_response_rate
             */
             // TODO: stub
-
-            // Prepare the external file to store this query's output
-            System.IO.FileInfo file = null;
-            if (!_prepareQueryOutput(MethodBase.GetCurrentMethod().Name, ref file))
-                return false;
-
-            // Open external file for storing query output, clears out previous text
-            using (System.IO.StreamWriter fout =
-                new System.IO.StreamWriter(file.FullName))
-            {
-                String output;
-                DateTime start;
-
-                Console.WriteLine('\n' + new string('-', 100) + '\n');
-                output = "Query 4 - Average";
-                fout.WriteLine(output);
-
-                start = DateTime.UtcNow;
-                // Run query on this line
-                output += $"\nQuery run time: {DateTime.UtcNow - start}";
-                logger.Info(output);
-                fout.WriteLine(output);
-            }
             return false;
         }
 
         /// <summary>
-        /// Query 5: Join
+        /// Query 5: Update
+        /// Update all listings that have more than 2 bedrooms and more than 2 bathrooms from Portland to require guest phone verification.
+        /// </summary>
+        /// <param name="fout">StreamWriter stream for for writing out query results</param>
+        /// <param name="collectionName">String representing the collection</param>
+        private bool _queryUpdate(String collectionName, StreamWriter fout)
+        {
+            /*  Implementation Strategy:
+            *      1. Perform an updateMany on all listings from Portland 
+            *         with greater than 2 bedrooms and 2 bathrooms to set the require_guest_phone_verification field as true. 
+            */
+            // TODO: stub
+            return false;
+        }
+
+        /// <summary>
+        /// Query 6: Join
         /// Return the most recent review for all listings from Portland with greater than 3 bedrooms that is also a house.
         /// </summary>
         /// <param name="firstCollection">String representing one collection</param>
         /// <param name="secondCollection">String representing a second collection</param>
-        private bool _queryJoin(String firstCollection, String secondCollection)
+        /// <param name="fout">StreamWriter stream for for writing out query results</param>
+        private bool _queryJoin(String firstCollection, String secondCollection, StreamWriter fout)
         {
             /*  Implementation Strategy:
             *      1. Perform a filter on the data to find all listings with city equal to “Portland” and greater than 3 bedrooms. 
@@ -633,68 +695,28 @@ namespace mongoCluster
             *      3. For each host id, return the max date from the reviews ($max). (This possibly can be completed before the lookup for efficiency)
             */
             // TODO: stub
-
-            // Prepare the external file to store this query's output
-            System.IO.FileInfo file = null;
-            if (!_prepareQueryOutput(MethodBase.GetCurrentMethod().Name, ref file))
-                return false;
-
-            // Open external file for storing query output, clears out previous text
-            using (System.IO.StreamWriter fout =
-                new System.IO.StreamWriter(file.FullName))
-            {
-                String output;
-                DateTime start;
-
-                Console.WriteLine('\n' + new string('-', 100) + '\n');
-                output = "Query 5 - Join";
-                fout.WriteLine(output);
-
-                start = DateTime.UtcNow;
-                // Run query on this line
-                output += $"\nQuery run time: {DateTime.UtcNow - start}";
-                logger.Info(output);
-                fout.WriteLine(output);
-            }
             return false;
         }
 
-        /// <summary>
-        /// Query 6: Update
-        /// Update all listings that have more than 2 bedrooms and more than 2 bathrooms from Portland to require guest phone verification.
-        /// </summary>
-        /// <param name="collectionName">String representing the collection</param>
-        private bool _queryUpdate(String collectionName)
+        /// <summary> Records the starting metrics of a query
+        /// <param name="queryName">String name of query to record</param>
+        /// <param name="fout">StreamWriter stream for for writing out query results</param>
+        private DateTime _startQueryMetrics(string queryName, StreamWriter fout)
+        { 
+            Console.WriteLine('\n' + new string('-', 100) + '\n');
+            fout.WriteLine(queryName);
+            return DateTime.UtcNow;
+        }
+
+        /// <summary> Records the final metrics of a query</summary>
+        /// <param name="fout">StreamWriter stream for for writing out query results</param>
+        /// <paramref name="start"/>The DateTime time that the query started</param>
+        private void _stopQueryMetrics(StreamWriter fout, DateTime start)
         {
-            /*  Implementation Strategy:
-            *      1. Perform an updateMany on all listings from Portland 
-            *         with greater than 2 bedrooms and 2 bathrooms to set the require_guest_phone_verification field as true. 
-            */
-            // TODO: stub
-
-            // Prepare the external file to store this query's output
-            System.IO.FileInfo file = null;
-            if (!_prepareQueryOutput(MethodBase.GetCurrentMethod().Name, ref file))
-                return false;
-
-            // Open external file for storing query output, clears out previous text
-            using (System.IO.StreamWriter fout =
-                new System.IO.StreamWriter(file.FullName))
-            {
-                String output;
-                DateTime start;
-
-                Console.WriteLine('\n' + new string('-', 100) + '\n');
-                output = "Query 6 - Update";
-                fout.WriteLine(output);
-
-                start = DateTime.UtcNow;
-                // Run query on this line
-                output += $"\nQuery run time: {DateTime.UtcNow - start}";
-                logger.Info(output);
-                fout.WriteLine(output);
-            }
-            return false;
+            DateTime stop = DateTime.UtcNow;
+            string output = $"\nQuery run time: {stop - start}";
+            logger.Info(output);
+            fout.WriteLine(output);
         }
     }
 }

--- a/mongoCluster/Program.cs
+++ b/mongoCluster/Program.cs
@@ -45,7 +45,6 @@ namespace mongoCluster
             if (driver.getCollection(_listings))
             {
                 // Run a simple query that counts the total number of listings
-                /*
                 long totalListings = driver.queryCountDocuments(_listings);
                 if (totalListings.Equals(0))
                 {
@@ -57,6 +56,7 @@ namespace mongoCluster
                     logger.Info($"There are {totalListings} totalListings");
                 }
 
+                /*
                 // Run a test query
                 if (!driver.queryTest(_listings)) {
                     logger.Error("Error: Test query failed");
@@ -69,26 +69,24 @@ namespace mongoCluster
 
                 // Query 2: Sorted Subset
                 if (!driver.querySortedSubset(_listings)) {
-                    logger.Error("Error: Query2: Sorted subset driver.query failed");
+                    logger.Error("Error: Query2: Sorted subset query failed");
                 }
-
 
                 // Query 3: Subset-search
                 if (!driver.querySubsetSearch(_listings)) {
-                    logger.Error("Error: Query3: Subset search driver.query failed");
+                    logger.Error("Error: Query3: Subset search query failed");
                 }
 
                 // Query 4: Average
                 if (!driver.queryAverage(_listings)) {
-                    logger.Error("Error: Query4: Average driver.query failed");
+                    logger.Error("Error: Query4: Average query failed");
                 }
 
-                // Query 6: Update
+                // Query 5: Update
                 if (!driver.queryUpdate(_listings)) {
-                    logger.Error("Error: Query6: Update query failed");
+                    logger.Error("Error: Query5: Update query failed");
                 }
                 */
-
 
             } // End queries specific to the listings collection
 
@@ -96,13 +94,15 @@ namespace mongoCluster
             // Run queries specific to the reviews collection if a successful connection is established
             if (driver.getCollection(_reviews))
             {
-                // Query 5: Join
+                // Query 6: Join
+                /*
                 if (!driver.queryJoin(_listings, _reviews))
                 {
-                    logger.Error("Error: Query5: Join driver.query failed");
+                    logger.Error("Error: Query6: Join query failed");
                 }
 
                 // Query ?: Join 2.0
+                */
                 
             } // End queries specific to the reviews collection
 

--- a/mongoCluster/mongoCluster.csproj
+++ b/mongoCluster/mongoCluster.csproj
@@ -22,4 +22,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="query_output\" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- move file writing, metric recording to query wrapper functions (note: the StreamWriter is passed onto the private query function so logging can continue)
- stubs are cleaned to be purely query focused
- create metric recording functions to reduce redundancy
- create test, import data, troubleshooting sections in README.md to simplify setup for a potentially first-time user